### PR TITLE
🎨design: 출석부 레이아웃 정렬 및 간격 개선

### DIFF
--- a/src/components/attendance/admin/AttendancePrintPage.js
+++ b/src/components/attendance/admin/AttendancePrintPage.js
@@ -228,7 +228,7 @@ const AttendancePrintPage = ({
               {summaryPage?.studentSummaries.map((student, idx) => (
                 <tr key={`summary-${student.studentId}`}>
                   <td>{idx + 1}</td>
-                  <td>{student.studentName}</td>
+                  <td className="course-name-cell">{student.studentName}</td>
                   <td>{courseName}</td>
                   <td>{student.totalWorkingDays}일</td>
                   <td>{student.attendanceDays}일</td>
@@ -236,6 +236,21 @@ const AttendancePrintPage = ({
                   <td>{student.lateDays}회</td>
                   <td>{student.earlyLeaveDays}회</td>
                   <td>{student.attendanceRate.toFixed(1)}%</td>
+                </tr>
+              ))}
+
+              {/* 학생 수가 15명 미만인 경우 빈 행 추가 */}
+              {Array.from({ length: Math.max(0, 15 - summaryPage.studentSummaries.length) }).map((_, idx) => (
+                <tr key={`empty-summary-${idx}`} className="empty-row">
+                  <td>{summaryPage.studentSummaries.length + idx + 1}</td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
                 </tr>
               ))}
               </tbody>

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -53,28 +53,32 @@
   /* 헤더 영역 */
   .header {
     width: 100% !important;
-    padding-bottom: 5px !important;
+    padding-bottom: 10px !important;
     margin-bottom: 5px !important;
   }
 
   .title {
-    font-size: 20px !important;
+    font-size: 30px !important;
     font-weight: normal !important;
     text-align: center !important;
-    margin-bottom: 5px !important;
+    margin: 20px !important;
   }
 
   .info-grid {
     display: grid !important;
-    grid-template-columns: repeat(4, 1fr) !important;
-    gap: 10px !important;
+    grid-template-columns: 0.8fr 1.5fr 0.9fr 0.8fr !important;
+    gap: 0 !important;
     font-size: 10px !important;
     width: 100% !important;
+    margin-top: 10px !important;
+    margin-bottom: 7px !important;
+    padding: 0 !important;
     text-align: center !important;
   }
 
   .info-grid > div {
-    padding: 2px !important;
+    width: 100% !important;
+    padding: 0px !important;
   }
 
   /* 테이블 컨테이너 */
@@ -91,14 +95,25 @@
     border: 1px solid #333 !important;
   }
 
-  .attendance-table th, .attendance-table td,
-  .summary-table th, .summary-table td {
+  .attendance-table th, .attendance-table td {
     border: 1px solid #333 !important;
     text-align: center !important;
     vertical-align: middle !important;
     font-size: 10px !important;
     overflow: visible !important;
     padding: 1px !important;
+  }
+
+  .summary-table th,
+  .summary-table td {
+    border: 1px solid #333 !important;
+    text-align: center !important;
+    vertical-align: middle !important;
+    font-size: 10px !important;
+    padding: 3px !important;
+    height: auto !important;
+    word-wrap: break-word !important; /* 긴 텍스트 줄바꿈 */
+    overflow-wrap: break-word !important;
   }
 
   /* 헤더 셀 스타일 */
@@ -113,6 +128,63 @@
   .attendance-table thead tr:nth-child(3) {
     height: 20px !important;
   }
+
+  .summary-table th:nth-child(1),
+  .summary-table td:nth-child(1) {
+    width: 25px !important;
+    min-width: 25px !important;
+    max-width: 25px !important;
+  }
+
+  /* 학생명 칸 좁게 */
+  .summary-table th:nth-child(2),
+  .summary-table td:nth-child(2) {
+    width: 50px !important;
+    min-width: 50px !important;
+    max-width: 50px !important;
+  }
+
+  /* 과목명 칸을 적절한 너비로 설정하고 줄바꿈 허용 */
+  .summary-table th:nth-child(3),
+  .summary-table td:nth-child(3) {
+    width: 120px !important;
+    min-width: 120px !important;
+    max-width: 120px !important;
+    white-space: normal !important; /* 줄바꿈 허용 */
+    word-break: break-word !important;
+    text-align: center !important; /* 왼쪽 정렬 */
+    padding-left: 5px !important;
+  }
+
+  /* 나머지 숫자 칸들 너비 조정 */
+  .summary-table th:nth-child(n+4),
+  .summary-table td:nth-child(n+4) {
+    width: 40px !important;
+    min-width: 40px !important;
+    max-width: 40px !important;
+  }
+
+  /* 출석률 칸 살짝 넓게 */
+  .summary-table th:nth-child(9),
+  .summary-table td:nth-child(9) {
+    width: 45px !important;
+    min-width: 45px !important;
+    max-width: 45px !important;
+  }
+
+  /* 요약 테이블 행 높이 고정 */
+  .summary-table tbody tr {
+    height: 9mm !important;
+    min-height: 9mm !important;
+    max-height: 12mm !important; /* 최대 높이 살짝 늘림 */
+  }
+
+  /* 요약 페이지 헤더 행 높이 조정 */
+  .summary-table thead tr {
+    height: auto !important;
+  }
+
+
 
   /* 출석부 테이블 레이아웃 조정 */
   .number-col {
@@ -207,7 +279,7 @@
     font-size: 11px !important;
     padding-top: 5px !important;
     padding-bottom: 5px !important;
-    border-top: 1px solid #ddd !important;
+    border-top: none !important;
     background-color: white !important;
     margin-top: 10px !important;
   }


### PR DESCRIPTION
- 푸터 상단 구분선 제거로 깔끔한 디자인 구현
- info-grid 영역을 테이블 너비에 맞게 조정
- 센터명과 기간 텍스트를 테이블 경계선에 맞춰 정렬
- 테이블과 헤더 사이 간격 최적화로 일관된 레이아웃 구현
- 요약 페이지 과목명 셀 가운데 정렬 적용