### PR TITLE
🐞fix: 출석부 통계 계산 로직 개선

### DIFF
--- a/src/components/attendance/admin/AttendancePrintPage.js
+++ b/src/components/attendance/admin/AttendancePrintPage.js
@@ -51,6 +51,33 @@ const AttendancePrintPage = ({
     return daysWithData.length;
   };
 
+  // 학생의 출석 통계를 계산하는 함수
+  const calculateStudentStats = (student) => {
+    // 실제 출석 데이터가 있는 날짜 수 계산
+    const totalActualDays = calculateActualAttendanceDays(student.dailyAttendance);
+
+    // 결석, 지각, 조퇴 횟수 계산
+    const absentCount = student.absentCount;
+    const lateCount = student.lateCount;
+    const earlyLeaveCount = student.earlyLeaveCount;
+
+    // 지각과 조퇴를 합쳐서 3번 이상일 경우 결석으로 처리
+    const latePlusEarlyLeave = lateCount + earlyLeaveCount;
+    const additionalAbsentDays = Math.floor(latePlusEarlyLeave / 3);
+
+    // 출석해야 할 총 일수에서 결석과 지각/조퇴로 인한 추가 결석을 뺀 값
+    const finalAttendanceDays = totalActualDays - absentCount - additionalAbsentDays;
+
+    return {
+      totalActualDays,
+      absentCount,
+      lateCount,
+      earlyLeaveCount,
+      additionalAbsentDays,
+      finalAttendanceDays
+    };
+  };
+
   // 항상 15명의 학생 행을 생성하는 함수 - 빈 행 클래스 추가
   const renderStudentRows = (pageStudents, dailyAttendanceTemplate) => {
     // 항상 15개의 행을 만들기 위한 배열
@@ -86,7 +113,14 @@ const AttendancePrintPage = ({
             })}
             {/* 통계 열 추가 */}
             <td className="stat-cell">{student.processedDays}</td>
-            <td className="stat-cell">{calculateActualAttendanceDays(student.dailyAttendance)}</td>
+            <td className="stat-cell">
+              {(() => {
+                // 학생 통계 계산
+                const stats = calculateStudentStats(student);
+                // 실제 출석일수 (결석과 지각/조퇴로 인한 추가 결석을 제외한 최종 출석일)
+                return stats.finalAttendanceDays;
+              })()}
+            </td>
             <td className="stat-cell">{student.absentCount}</td>
             <td className="stat-cell">{student.lateCount}</td>
             <td className="stat-cell">{student.earlyLeaveCount}</td>

--- a/src/components/attendance/admin/PrintDialog.js
+++ b/src/components/attendance/admin/PrintDialog.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Printer } from 'lucide-react';
 import AttendancePrintPage from './AttendancePrintPage';
-
 
 const PrintDialog = ({
   isOpen,
@@ -176,6 +175,35 @@ const PrintDialog = ({
       day.periods && day.periods.some(period => period.status)
     );
     return daysWithData.length;
+  };
+
+  // 학생의 출석 통계를 계산하는 함수
+  const calculateStudentStats = (student) => {
+    // 실제 출석 데이터가 있는 날짜 수 계산
+    const totalActualDays = calculateActualAttendanceDays(
+      student.dailyAttendance);
+
+    // 결석, 지각, 조퇴 횟수 계산
+    const absentCount = student.absentCount;
+    const lateCount = student.lateCount;
+    const earlyLeaveCount = student.earlyLeaveCount;
+
+    // 지각과 조퇴를 합쳐서 3번 이상일 경우 결석으로 처리
+    const latePlusEarlyLeave = lateCount + earlyLeaveCount;
+    const additionalAbsentDays = Math.floor(latePlusEarlyLeave / 3);
+
+    // 출석해야 할 총 일수에서 결석과 지각/조퇴로 인한 추가 결석을 뺀 값
+    const finalAttendanceDays = totalActualDays - absentCount
+      - additionalAbsentDays;
+
+    return {
+      totalActualDays,
+      absentCount,
+      lateCount,
+      earlyLeaveCount,
+      additionalAbsentDays,
+      finalAttendanceDays,
+    };
   };
 
   return (
@@ -374,7 +402,14 @@ const PrintDialog = ({
                             <td
                               className="border border-gray-800 p-2 text-center">{student.processedDays}</td>
                             <td
-                              className="border border-gray-800 p-2 text-center">{calculateActualAttendanceDays(student.dailyAttendance)}</td>
+                              className="border border-gray-800 p-2 text-center">
+                              {(() => {
+                                // 학생 통계 계산
+                                const stats = calculateStudentStats(student);
+                                // 실제 출석일수 (결석과 지각/조퇴로 인한 추가 결석을 제외한 최종 출석일)
+                                return stats.finalAttendanceDays;
+                              })()}
+                            </td>
                             <td
                               className="border border-gray-800 p-2 text-center">{student.absentCount}</td>
                             <td


### PR DESCRIPTION
- 실제 출석 데이터가 있는 날만 카운트하는 함수 추가
- 지각과 조퇴 횟수 합산해서 3회 이상일 경우 결석으로 처리하는 로직 구현
- 실제출석일 표시 부분을 최종 인정되는 출석일로 변경
- 결석 표시는 실제 결석일만 표시하도록 유지

이 변경을 통해 학생의 실질적인 출석 현황을 더 정확하게 표시할 수 있게 됨